### PR TITLE
Make file paths clickable in PyCharm

### DIFF
--- a/stackprinter/frame_formatting.py
+++ b/stackprinter/frame_formatting.py
@@ -281,7 +281,7 @@ class ColorfulFrameFormatter(FrameFormatter):
         dots = self.tpl('dots')
         lineno = self.tpl('lineno')
 
-        self.headline_tpl = header % "File %s%s" + highlight % "%s" + header % ", line %s, in %s\n"
+        self.headline_tpl = header % 'File "%s%s' + highlight % '%s' + header % '", line %s, in %s\n'
         self.sourceline_tpl = lineno % super().sourceline_tpl
         self.marked_sourceline_tpl = arrow_lineno % super().marked_sourceline_tpl
         self.elipsis_tpl = dots % super().elipsis_tpl

--- a/stackprinter/frame_formatting.py
+++ b/stackprinter/frame_formatting.py
@@ -10,7 +10,7 @@ from stackprinter.prettyprinting import format_value
 from stackprinter.utils import inspect_callable, match, trim_source, get_ansi_tpl
 
 class FrameFormatter():
-    headline_tpl = "File %s, line %s, in %s\n"
+    headline_tpl = 'File "%s", line %s, in %s\n'
     sourceline_tpl = "    %-3s  %s"
     single_sourceline_tpl = "    %s"
     marked_sourceline_tpl = "--> %-3s  %s"

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -6,7 +6,7 @@ def test_frame_formatting():
     msg = stackprinter.format()
     lines = msg.split('\n')
 
-    expected = ['File test_formatting.py, line 6, in test_frame_formatting',
+    expected = ['File "test_formatting.py", line 6, in test_frame_formatting',
                 '    4    def test_frame_formatting():',
                 '    5        """ pin plaintext output """',
                 '--> 6        msg = stackprinter.format()',


### PR DESCRIPTION
This makes lines such as 

> `File "/Users/alexhall/git-repos/stackprinter/demo_chained_exceptions.py", line 7, in bomb`

look exactly the same as regular traceback lines, which makes PyCharm (and possibly other editors) recognise them and turn them into clickable links which jump to the file at the appropriate line in the editor. It looks like this:

![Screen Shot 2019-08-24 at 18 35 19](https://user-images.githubusercontent.com/3627481/63640226-f2f7c500-c69d-11e9-94f1-c7f70f2fe968.png)

The only difference is that the file paths have quotes around them.