### PR TITLE
Allow patching stderr

### DIFF
--- a/stackprinter/__init__.py
+++ b/stackprinter/__init__.py
@@ -142,7 +142,7 @@ def format(thing=None, **kwargs):
 
 
 @_guess_thing
-def show(thing=None, file=sys.stderr, **kwargs):
+def show(thing=None, file='stderr', **kwargs):
     """
     Print the traceback of an exception or a frame's call stack
 


### PR DESCRIPTION
People often 'redirect' stderr by replacing it with something else. This ensures that that works with the default settings. Here's a script to demonstrate the difference:

```python
import sys
from io import StringIO
import stackprinter

sys.stderr = s = StringIO()

try:
    1 / 0
except:
    stackprinter.show()

print(repr(s.getvalue()))
```
