### PR TITLE
Use tb_or_frame instead of undefined tb

### DIFF
--- a/stackprinter/extraction.py
+++ b/stackprinter/extraction.py
@@ -70,7 +70,7 @@ def get_info(tb_or_frame, lineno=None):
         frame = tb_or_frame
         lineno = frame.f_lineno if lineno is None else lineno
     else:
-        raise ValueError('Cant inspect this: ' + repr(tb))
+        raise ValueError('Cant inspect this: ' + repr(tb_or_frame))
 
     filename = inspect.getsourcefile(frame) or inspect.getfile(frame)
     function = frame.f_code.co_name


### PR DESCRIPTION
This code:

```python
from stackprinter.extraction import get_info

get_info(None)
```

raises:

```
Traceback (most recent call last):
  File "/Users/alexhall/Library/Preferences/PyCharm2018.3/scratches/scratch_421.py", line 3, in <module>
    get_info(None)
  File "/Users/alexhall/git-repos/stackprinter/stackprinter/extraction.py", line 73, in get_info
    raise ValueError('Cant inspect this: ' + repr(tb))
UnboundLocalError: local variable 'tb' referenced before assignment
```

This PR changes it to the correct:

```
ValueError: Cant inspect this: None
```