### PR TITLE
Simplify code relating to get_info

### DIFF
--- a/stackprinter/extraction.py
+++ b/stackprinter/extraction.py
@@ -68,6 +68,10 @@ def get_info(tb_or_frame, lineno=None):
             so maybe just do that & let formatting decide which parts to show?)
             (TODO: Support []-lookups just like . lookups)
     """
+
+    if isinstance(tb_or_frame, FrameInfo):
+        return tb_or_frame
+
     if isinstance(tb_or_frame, types.TracebackType):
         tb = tb_or_frame
         lineno = tb.tb_lineno if lineno is None else lineno

--- a/stackprinter/formatting.py
+++ b/stackprinter/formatting.py
@@ -17,16 +17,6 @@ def get_formatter(style, **kwargs):
         return ColorfulFrameFormatter(style, **kwargs)
 
 
-def inspect_frames(frames):
-    for fi in frames:
-        if isinstance(fi, ex.FrameInfo):
-            yield fi
-        elif isinstance(fi, types.FrameType):
-            yield ex.get_info(fi)
-        else:
-            raise ValueError("Expected a frame or a FrameInfo tuple, got %r" % fi)
-
-
 def format_summary(frames, style='plaintext', source_lines=1, reverse=False,
                    **kwargs):
     """
@@ -40,7 +30,7 @@ def format_summary(frames, style='plaintext', source_lines=1, reverse=False,
                                       show_signature=False,
                                       show_vals=False)
 
-    frame_msgs = [minimal_formatter(fi) for fi in inspect_frames(frames)]
+    frame_msgs = [minimal_formatter(frame) for frame in frames]
     if reverse:
         frame_msgs = reversed(frame_msgs)
 
@@ -80,7 +70,8 @@ def format_stack(frames, style='plaintext', source_lines=5,
 
     frame_msgs = []
     parent_is_boring = True
-    for fi in inspect_frames(frames):
+    for frame in frames:
+        fi = ex.get_info(frame)
         is_boring = match(fi.filename, suppressed_paths)
         if is_boring:
             if parent_is_boring:
@@ -109,7 +100,7 @@ def format_stack_from_frame(fr, add_summary=False, **kwargs):
     """
     stack = []
     while fr is not None:
-        stack.append(ex.get_info(fr))
+        stack.append(fr)
         fr = fr.f_back
     stack = reversed(stack)
 

--- a/stackprinter/frame_formatting.py
+++ b/stackprinter/frame_formatting.py
@@ -117,10 +117,7 @@ class FrameFormatter():
                              "%s. Got %r" % (accepted_types, frame))
 
         try:
-            if isinstance(frame, ex.FrameInfo):
-                finfo = frame
-            else:
-                finfo = ex.get_info(frame, lineno)
+            finfo = ex.get_info(frame, lineno)
 
             return self._format_frame(finfo)
         except Exception as exc:


### PR DESCRIPTION
This essentially 'flattens' the code and makes it a bit easier to understand and reason about. `get_info` is only called in two places (one of which is hardly needed) and there's less need to check types.