### PR TITLE
Cleanup debug formatting

### DIFF
--- a/stackprinter/extraction.py
+++ b/stackprinter/extraction.py
@@ -3,11 +3,18 @@ import inspect
 from collections import OrderedDict, namedtuple
 from stackprinter.source_inspection import annotate
 
-FrameInfo = namedtuple('FrameInfo',
-                       ['filename', 'function', 'lineno', 'source_map',
-                        'head_lns', 'line2names', 'name2lines', 'assignments'])
-
 NON_FUNCTION_SCOPES =  ['<module>', '<lambda>', '<listcomp>']
+
+_FrameInfo = namedtuple('_FrameInfo',
+                        ['filename', 'function', 'lineno', 'source_map',
+                         'head_lns', 'line2names', 'name2lines', 'assignments'])
+
+class FrameInfo(_FrameInfo):
+    # give this namedtuple type a friendlier string representation
+    def __str__(self):
+        return ("<FrameInfo %s, line %s, scope %s>" %
+                (self.filename, self.lineno, self.function))
+
 
 def get_info(tb_or_frame, lineno=None):
     """
@@ -61,7 +68,6 @@ def get_info(tb_or_frame, lineno=None):
             so maybe just do that & let formatting decide which parts to show?)
             (TODO: Support []-lookups just like . lookups)
     """
-
     if isinstance(tb_or_frame, types.TracebackType):
         tb = tb_or_frame
         lineno = tb.tb_lineno if lineno is None else lineno

--- a/stackprinter/formatting.py
+++ b/stackprinter/formatting.py
@@ -195,7 +195,7 @@ def format_exc_info(etype, evalue, tb, style='plaintext', add_summary='auto',
                                             exc,
                                             exc.__traceback__,
                                             chain=False)
-        where = ', '.join(str(w) for w in getattr(exc, 'where', []))
+        where = getattr(exc, 'where', None)
         context = " while formatting " + str(where) if where else ''
         msg = 'Stackprinter failed%s:\n%s\n' % (context, ''.join(our_tb[-2:]))
         msg += 'So here is your original traceback at least:\n\n'

--- a/stackprinter/frame_formatting.py
+++ b/stackprinter/frame_formatting.py
@@ -124,10 +124,9 @@ class FrameFormatter():
 
             return self._format_frame(finfo)
         except Exception as exc:
-            if isinstance(frame, ex.FrameInfo):
-                exc.where = [finfo.filename, finfo.function, finfo.lineno]
-            else:
-                exc.where = frame
+            # If we crash, annotate the exception with the thing
+            # we were trying to format, for debug/logging purposes.
+            exc.where = frame
             raise
 
     def _format_frame(self, fi):


### PR DESCRIPTION
define type-specific formatting logic down where it belongs, in the type definition