### PR TITLE
Add option to show the parent frames of the exception handling site

### DIFF
--- a/demo_outerframes.py
+++ b/demo_outerframes.py
@@ -1,0 +1,60 @@
+import traceback
+import stackprinter
+
+
+def function1(x):
+    raise RuntimeError('xxx')
+
+def function2(x):
+    function1(x)
+
+def function3(x):
+    try:
+        function2(x)
+    except Exception:
+        # traceback.print_exc()
+        stackprinter.show(style='color', add_prior_calls=True, add_summary=True)
+
+def function4(x):
+    function3(x)
+
+def function5(x):
+    function4(x)
+
+function5(x=1)
+
+
+
+# import stackprinter
+# stackprinter.set_excepthook(style='darkbg2', add_prior_calls=True, add_summary=True)
+
+# from PyQt5.QtWidgets import *
+# from PyQt5.QtCore import Qt
+
+# class Window(QWidget):
+#     def __init__(self):
+#         super().__init__()
+#         b1 = QPushButton('1')
+#         b2 = QPushButton('2')
+#         b1.clicked.connect(self.f1)
+#         b2.clicked.connect(self.f2)
+#         layout = QVBoxLayout(self)
+#         layout.addWidget(b1)
+#         layout.addWidget(b2)
+#         self.setLayout(layout)
+#     def f1(self, _):
+#         self.inputMethodQuery(Qt.ImAnchorPosition)
+#     def f2(self, _):
+#         self.inputMethodQuery(Qt.ImAnchorPosition)
+#     def inputMethodQuery(self, query):
+#         if query == Qt.ImCursorPosition:
+#             self.h()
+#         else:
+#             return super().inputMethodQuery(query) # Call 'g()'
+#     def h(self):
+#         raise Exception()
+
+# app = QApplication([])
+# window = Window()
+# window.show()
+# app.exec()

--- a/stackprinter/__init__.py
+++ b/stackprinter/__init__.py
@@ -25,7 +25,7 @@ def _guess_thing(f):
 
 
 @_guess_thing
-def format(thing=None, **kwargs):
+def format(thing=None, add_prior_calls=False, **kwargs):
     """
     Render the traceback of an exception or a frame's call stack
 
@@ -125,6 +125,13 @@ def format(thing=None, **kwargs):
         to the built-in traceback message.
         'auto' (default): do that if the main traceback is longer than 50 lines.
 
+    add_prior_calls: bool
+        If a traceback's top frame itself has parent frames, display
+        those as well. By default, Python tracebacks only show the frames
+        below the exception handling site (i.e. you only only see what
+        happened inside your try block, but you don't see which prior
+        calls have led to that block). This option adds such parent frames
+        to the printout.
     """
     if isinstance(thing, types.FrameType):
         return fmt.format_stack_from_frame(thing, **kwargs)
@@ -134,7 +141,7 @@ def format(thing=None, **kwargs):
         exc_info = (thing.__class__, thing, thing.__traceback__)
         return format(exc_info, **kwargs)
     elif _is_exc_info(thing):
-        return fmt.format_exc_info(*thing, **kwargs)
+        return fmt.format_exc_info(*thing, add_prior_calls=add_prior_calls, **kwargs)
     else:
         raise ValueError("Can't format %s. "\
                          "Expected an exception instance, sys.exc_info() tuple,"\


### PR DESCRIPTION
Following the suggestion by https://github.com/cknd/stackprinter/issues/26 , this adds an option to show caller frames of the frame where an exception is handled (& printerd). By default, Python tracebacks only show the frames below the exception handling site (i.e. you only only see what happened inside your try block, but you don't see which prior calls have led to that block). This option adds such parent frames to the printout.  

It seems to be helpful in [this case](http://blog.dscpl.com.au/2015/03/generating-full-stack-traces-for.html) and things like [this Qt example](https://fman.io/blog/pyqt-excepthook/)