### PR TITLE
Fail more gracefully in case the standard output streams aren't available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.7 - August 12, 2022
+
+## Fixed
+- Degrade more gracefully in environments where the standard output streams (stdout, stderr) are not available, such as the `pythonw.exe` GUI. Concretely: 1) If stackprinter's `show()` function is called in such an environment and with default arguments, it will now return silently (doing nothing) instead of crashing. 2) the 'Traceprinter' toy now uses the built in print function (so that it doesn't try to access sys.stderr.write on import).
+
 # 0.2.6 - April 2, 2022
 
 ## Added

--- a/stackprinter/__init__.py
+++ b/stackprinter/__init__.py
@@ -175,6 +175,20 @@ def show(thing=None, file='stderr', **kwargs):
     **kwargs:
         See `format`
     """
+
+    # First, to handle a very rare edge case:
+    # Apparently there are environments where sys.stdout and stderr
+    # are None (like the pythonw.exe GUI https://stackoverflow.com/a/30313091).
+    # In those cases, it's not clear where our output should go unless the user
+    # specifies their own file for output. So I'll make a pragmatic assumption:
+    # If `show` is called with the default 'stderr' argument but we are in an
+    # environment where that stream doesn't exist, we're most likely running as
+    # part of a library that's imported in someone's GUI project and there just
+    # isn't any error logging (if there was, the user would've given us a file).
+    # So the least annoying behavior for us is to return silently, not crashing.
+    if file == 'stderr' and sys.stderr is None:
+        return
+
     if file == 'stderr':
         file = sys.stderr
     elif file == 'stdout':
@@ -227,6 +241,8 @@ def show_current_exception(file=sys.stderr, **kwargs):
     **kwargs:
         See `show`
     """
+    if file is None:
+        return # see explanation in `show()`
     print(format_current_exception(**kwargs), file=file)
 
 

--- a/stackprinter/tracing.py
+++ b/stackprinter/tracing.py
@@ -25,7 +25,7 @@ def trace(*args, suppressed_paths=[], **formatter_kwargs):
     depth_limit: int (default: 20)
         How many nested calls will be followed
 
-    print_function: callable (default: sys.stderr.write)
+    print_function: callable (default: print)
         some function of your choice that accepts a string
 
     stop_on_exception: bool (default: True)
@@ -68,7 +68,7 @@ class TracePrinter():
     depth_limit: int (default: 20)
         How many nested calls will be followed
 
-    print_function: callable (default: sys.stderr.write)
+    print_function: callable (default: print)
         some function of your choice that accepts a string
 
     stop_on_exception: bool (default: True)
@@ -79,7 +79,7 @@ class TracePrinter():
     def __init__(self,
                  suppressed_paths=[],
                  depth_limit=20,
-                 print_function=sys.stderr.write,
+                 print_function=print,
                  stop_on_exception=True,
                  **formatter_kwargs):
 


### PR DESCRIPTION
Adressing https://github.com/cknd/stackprinter/issues/55