### PR TITLE
No module named 'packaging'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/cknd/stackprinter",
     packages=setuptools.find_packages(),
+    install_requires=['packaging>=21'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Import fails since #57 
`setuptools.find_packages()` can't obtain `packaging`

Steps to reproduce:
`docker run -it python:3.9-slim /bin/bash -c "pip install numpy stackprinter && python -c 'import stackprinter'"`