### PR TITLE
Support colorscheme with only basic ANSI color sequences

### DIFF
--- a/stackprinter/__init__.py
+++ b/stackprinter/__init__.py
@@ -82,6 +82,9 @@ def format(thing=None, **kwargs):
     style: string
         'plaintext' (default): Output just text
 
+        'ansi': Enable colors, using basic ansi sequences. It is compatible
+            with light and dark background, based on terminal settings.
+
         'darkbg', 'darkbg2', 'darkbg3', 'lightbg', 'lightbg2', 'lightbg3':
             Enable colors, for use in terminals that support 256 ansi
             colors or in jupyter notebooks (or even with `ansi2html`)

--- a/stackprinter/colorschemes.py
+++ b/stackprinter/colorschemes.py
@@ -24,11 +24,41 @@ class plaintext(ColorScheme):
         return "%s"
 
 
-class HslScheme(ColorScheme):
-    colors = {}
+class ansi(ColorScheme):
+    colors = {
+        'exception_type': '31',
+        'exception_msg': '31',
+        'highlight': '1;31',
+        'header': '0',
+        'lineno': '1',
+        'arrow_lineno': '1',
+        'dots': '0',
+        'source_bold': '0',
+        'source_default': '0',
+        'source_comment': '0',
+        'var_invisible': '0',
+    }
 
     def __init__(self):
         self.rng = random.Random()
+
+    def __getitem__(self, name):
+        return self._ansi_tpl(self.colors[name])
+
+    def get_random(self, seed, highlight):
+        self.rng.seed(seed)
+        random_code = str(self.rng.randint(32, 36))
+        if self.rng.choice((True, False)):
+            random_code = "1;" + random_code
+        return self._ansi_tpl(random_code)
+
+    @staticmethod
+    def _ansi_tpl(color_code):
+        return f"\u001b[{color_code}m%s\u001b[0m"
+
+
+class HslScheme(ColorScheme):
+    colors = {}
 
     def __getitem__(self, name):
         return self._ansi_tpl(*self.colors[name])
@@ -216,6 +246,22 @@ color = darkbg2
 
 
 if __name__ == '__main__':
+    scheme = darkbg3()
+    for attr in [
+        'exception_type',
+        'exception_msg',
+        'highlight',
+        'header',
+        'lineno',
+        'arrow_lineno',
+        'dots',
+        'source_bold',
+        'source_default',
+        'source_comment',
+        'var_invisible',
+    ]:
+        print(scheme[attr] % attr)
+    exit()
     import numpy as np
     hsl_scheme = HslScheme()
 

--- a/stackprinter/colorschemes.py
+++ b/stackprinter/colorschemes.py
@@ -1,4 +1,5 @@
 import random
+import colorsys
 
 
 __all__ = ['color', 'darkbg', 'darkbg2', 'darkbg3',
@@ -20,14 +21,26 @@ class HslScheme(ColorScheme):
         self.rng = random.Random()
 
     def __getitem__(self, name):
-        return self.colors[name]
+        return self._ansi_tpl(*self.colors[name])
 
     def get_random(self, seed, highlight):
         self.rng.seed(seed)
-        return self._random_color(highlight)
+        return self._ansi_tpl(*self._random_color(highlight))
 
     def _random_color(self, highlight):
         raise NotImplemented
+
+    @staticmethod
+    def _ansi_tpl(hue, sat, val, bold=False):
+        r_, g_, b_ = colorsys.hsv_to_rgb(hue, sat, val)
+        r = int(round(r_*5))
+        g = int(round(g_*5))
+        b = int(round(b_*5))
+        point = 16 + 36 * r + 6 * g + b
+
+        bold_tp = '1;' if bold else ''
+        code_tpl = ('\u001b[%s38;5;%dm' % (bold_tp, point)) + '%s\u001b[0m'
+        return code_tpl
 
 
 class darkbg(HslScheme):
@@ -194,14 +207,14 @@ color = darkbg2
 
 if __name__ == '__main__':
     import numpy as np
-    from utils import get_ansi_tpl
+    hsl_scheme = HslScheme()
 
     for hue in np.arange(0,1.05,0.05):
         print('\n\nhue %.2f\nsat' % hue)
         for sat in np.arange(0,1.05,0.05):
             print('%.2f  ' % sat, end='')
             for val in np.arange(0,1.05,0.05):
-                tpl = get_ansi_tpl(hue, sat, val)
+                tpl = hsl_scheme._ansi_tpl(hue, sat, val)
                 # number = " (%.1f %.1f %.1f)" % (hue, sat, val)
                 number = ' %.2f' % val
                 print(tpl % number, end='')

--- a/stackprinter/colorschemes.py
+++ b/stackprinter/colorschemes.py
@@ -2,7 +2,8 @@ import random
 import colorsys
 
 
-__all__ = ['color', 'darkbg', 'darkbg2', 'darkbg3',
+__all__ = ['plaintext', 'color',
+           'darkbg', 'darkbg2', 'darkbg3',
            'lightbg', 'lightbg2', 'lightbg3']
 
 class ColorScheme():
@@ -10,8 +11,17 @@ class ColorScheme():
     def __getitem__(self, name):
         raise NotImplemented
 
-    def get_random(self):
+    def get_random(self, seed, highlight):
         raise NotImplemented
+
+
+class plaintext(ColorScheme):
+
+    def __getitem__(self, name):
+        return "%s"
+
+    def get_random(self, seed, highlight):
+        return "%s"
 
 
 class HslScheme(ColorScheme):

--- a/stackprinter/colorschemes.py
+++ b/stackprinter/colorschemes.py
@@ -13,7 +13,24 @@ class ColorScheme():
         raise NotImplemented
 
 
-class darkbg(ColorScheme):
+class HslScheme(ColorScheme):
+    colors = {}
+
+    def __init__(self):
+        self.rng = random.Random()
+
+    def __getitem__(self, name):
+        return self.colors[name]
+
+    def get_random(self, seed, highlight):
+        self.rng.seed(seed)
+        return self._random_color(highlight)
+
+    def _random_color(self, highlight):
+        raise NotImplemented
+
+
+class darkbg(HslScheme):
                               # Hue, Sat, Val, Bold
     colors = {'exception_type': (0.0, 0.9, 0.6, False),
               'exception_msg':  (0.0, 0.9, 0.6, True),
@@ -31,27 +48,17 @@ class darkbg(ColorScheme):
               'var_invisible':  (0.6, 0.4, 0.4, False)
              }
 
-    def __init__(self):
-        self.rng = random.Random()
-
-    def __getitem__(self, name):
-        return self.colors[name]
-
-    def get_random(self, seed, highlight):
-        self.rng.seed(seed)
-
+    def _random_color(self, highlight):
         hue = self.rng.uniform(0.05,0.7)
-        # if hue < 0:
-        #     hue = hue + 1
-        sat = 1. #1. if highlight else 0.5
-        val = 0.5 #1. if highlight else 0.3
+        sat = 1.0
+        val = 0.5
         bold = highlight
 
         return hue, sat, val, bold
 
 
 
-class darkbg2(ColorScheme):
+class darkbg2(HslScheme):
                               # Hue, Sat, Val, Bold
     colors = {'exception_type': (0., 1., 0.8, True),
               'exception_msg':  (0., 1., 0.8, True),
@@ -69,26 +76,16 @@ class darkbg2(ColorScheme):
               'var_invisible':  (0.6, 0.4, 0.4, False)
              }
 
-    def __init__(self):
-        self.rng = random.Random()
-
-    def __getitem__(self, name):
-        return self.colors[name]
-
-    def get_random(self, seed, highlight):
-        self.rng.seed(seed)
-
+    def _random_color(self, highlight):
         hue = self.rng.uniform(0.05,0.7)
-        # if hue < 0:
-        #     hue = hue + 1
-        sat = 1. if highlight else 1.
-        val = 0.8 #if highlight else 0.5
+        sat = 1.0
+        val = 0.8
         bold = highlight
 
         return hue, sat, val, bold
 
 
-class darkbg3(ColorScheme):
+class darkbg3(HslScheme):
                               # Hue, Sat, Val, Bold
     colors = {'exception_type': (0., 1., 0.8, True),
               'exception_msg':  (0., 1., 0.8, True),
@@ -103,26 +100,16 @@ class darkbg3(ColorScheme):
               'var_invisible':  (0.6, 0.4, 0.4, False)
              }
 
-    def __init__(self):
-        self.rng = random.Random()
-
-    def __getitem__(self, name):
-        return self.colors[name]
-
-    def get_random(self, seed, highlight):
-        self.rng.seed(seed)
-
+    def _random_color(self, highlight):
         hue = self.rng.uniform(0.05,0.7)
-        # if hue < 0:
-        #     hue = hue + 1
-        sat = 1. if highlight else 1.
+        sat = 1.0
         val = 0.8 if highlight else 0.5
         bold = highlight
 
         return hue, sat, val, bold
 
 
-class lightbg(ColorScheme):
+class lightbg(HslScheme):
                               # Hue, Sat, Val, Bold
     colors = {'exception_type': (0.0, 1., 0.6, False),
               'exception_msg':  (0.0, 1., 0.6, True),
@@ -139,26 +126,16 @@ class lightbg(ColorScheme):
               'var_invisible':  (0.6, 0.4, 0.2, False)
              }
 
-    def __init__(self):
-        self.rng = random.Random()
-
-    def __getitem__(self, name):
-        return self.colors[name]
-
-    def get_random(self, seed, highlight):
-        self.rng.seed(seed)
-
+    def _random_color(self, highlight):
         hue = self.rng.uniform(0.05, 0.7)
-        # if hue < 0:
-        #     hue = hue + 1
-        sat = 1.
-        val = 0.5 #0.5 #0.6 if highlight else 0.2
+        sat = 1.0
+        val = 0.5
         bold = highlight
 
         return hue, sat, val, bold
 
 
-class lightbg2(ColorScheme):
+class lightbg2(HslScheme):
                               # Hue, Sat, Val, Bold
     colors = {'exception_type': (0.0, 1., 0.6, False),
               'exception_msg':  (0.0, 1., 0.6, True),
@@ -176,25 +153,15 @@ class lightbg2(ColorScheme):
               'var_invisible':  (0.6, 0.4, 0.2, False)
              }
 
-    def __init__(self):
-        self.rng = random.Random()
-
-    def __getitem__(self, name):
-        return self.colors[name]
-
-    def get_random(self, seed, highlight):
-        self.rng.seed(seed)
-
+    def _random_color(self, highlight):
         hue = self.rng.uniform(0.05, 0.7)
-        # if hue < 0:
-        #     hue = hue + 1
-        sat = 1.
+        sat = 1.0
         val = 0.5
         bold = True
 
         return hue, sat, val, bold
 
-class lightbg3(ColorScheme):
+class lightbg3(HslScheme):
                               # Hue, Sat, Val, Bold
     colors = {'exception_type': (0.0, 1., 0.7, False),
               'exception_msg':  (0.0, 1., 0.7, True),
@@ -212,19 +179,9 @@ class lightbg3(ColorScheme):
               'var_invisible':  (0.6, 0.4, 0.2, False)
              }
 
-    def __init__(self):
-        self.rng = random.Random()
-
-    def __getitem__(self, name):
-        return self.colors[name]
-
-    def get_random(self, seed, highlight):
-        self.rng.seed(seed)
-
+    def _random_color(self, highlight):
         hue = self.rng.uniform(0.05, 0.7)
-        # if hue < 0:
-        #     hue = hue + 1
-        sat = 1.
+        sat = 1.0
         val = 0.5
         bold = True
 

--- a/stackprinter/formatting.py
+++ b/stackprinter/formatting.py
@@ -11,10 +11,7 @@ from stackprinter.frame_formatting import FrameFormatter, ColorfulFrameFormatter
 
 
 def get_formatter(style, **kwargs):
-    if style in ['plaintext', 'plain']:
-        return FrameFormatter(**kwargs)
-    else:
-        return ColorfulFrameFormatter(style, **kwargs)
+    return ColorfulFrameFormatter(style, **kwargs)
 
 
 def format_summary(frames, style='plaintext', source_lines=1, reverse=False,
@@ -155,12 +152,9 @@ def format_exc_info(etype, evalue, tb, style='plaintext', add_summary='auto',
                                    suppressed_vars=suppressed_vars,
                                    **kwargs)
 
-            if style == 'plaintext':
-                msg +=  chain_hint
-            else:
-                sc = getattr(colorschemes, style)()
-                clr = sc['exception_type']
-                msg += clr % chain_hint
+            sc = getattr(colorschemes, style)()
+            clr = sc['exception_type']
+            msg += clr % chain_hint
 
         # Now, actually do some formatting:
         parts = []
@@ -226,15 +220,12 @@ def format_exception_message(etype, evalue, tb=None, style='plaintext'):
     if val_str:
         type_str += ": "
 
-    if style == 'plaintext':
-        return type_str + val_str
-    else:
-        sc = getattr(colorschemes, style)()
+    sc = getattr(colorschemes, style)()
 
-        clr_head = sc['exception_type']
-        clr_msg = sc['exception_msg']
+    clr_head = sc['exception_type']
+    clr_msg = sc['exception_msg']
 
-        return clr_head % type_str + clr_msg % val_str
+    return clr_head % type_str + clr_msg % val_str
 
 
 def _walk_traceback(tb):

--- a/stackprinter/formatting.py
+++ b/stackprinter/formatting.py
@@ -6,7 +6,7 @@ import traceback
 
 import stackprinter.extraction as ex
 import stackprinter.colorschemes as colorschemes
-from stackprinter.utils import match, get_ansi_tpl
+from stackprinter.utils import match
 from stackprinter.frame_formatting import FrameFormatter, ColorfulFrameFormatter
 
 
@@ -158,8 +158,8 @@ def format_exc_info(etype, evalue, tb, style='plaintext', add_summary='auto',
             if style == 'plaintext':
                 msg +=  chain_hint
             else:
-                sc = getattr(colorschemes, style)
-                clr = get_ansi_tpl(*sc.colors['exception_type'])
+                sc = getattr(colorschemes, style)()
+                clr = sc['exception_type']
                 msg += clr % chain_hint
 
         # Now, actually do some formatting:
@@ -229,10 +229,10 @@ def format_exception_message(etype, evalue, tb=None, style='plaintext'):
     if style == 'plaintext':
         return type_str + val_str
     else:
-        sc = getattr(colorschemes, style)
+        sc = getattr(colorschemes, style)()
 
-        clr_head = get_ansi_tpl(*sc.colors['exception_type'])
-        clr_msg = get_ansi_tpl(*sc.colors['exception_msg'])
+        clr_head = sc['exception_type']
+        clr_msg = sc['exception_msg']
 
         return clr_head % type_str + clr_msg % val_str
 

--- a/stackprinter/frame_formatting.py
+++ b/stackprinter/frame_formatting.py
@@ -7,7 +7,7 @@ import stackprinter.source_inspection as sc
 import stackprinter.colorschemes as colorschemes
 
 from stackprinter.prettyprinting import format_value
-from stackprinter.utils import inspect_callable, match, trim_source, get_ansi_tpl
+from stackprinter.utils import inspect_callable, match, trim_source
 
 class FrameFormatter():
     headline_tpl = 'File "%s", line %s, in %s\n'
@@ -283,7 +283,7 @@ class ColorfulFrameFormatter(FrameFormatter):
         super().__init__(**kwargs)
 
     def tpl(self, name):
-        return get_ansi_tpl(*self.colors[name])
+        return self.colors[name]
 
     def _format_frame(self, fi):
         basepath, filename = os.path.split(fi.filename)
@@ -319,8 +319,7 @@ class ColorfulFrameFormatter(FrameFormatter):
                     if snippet not in colormap:
                         line += default_tpl % snippet
                     else:
-                        hue, sat, val, bold = colormap[snippet]
-                        var_tpl = get_ansi_tpl(hue, sat, val, bold)
+                        var_tpl = colormap[snippet]
                         line += var_tpl % snippet
                 elif ttype == sc.CALL:
                     line += bold_tp % snippet
@@ -340,8 +339,7 @@ class ColorfulFrameFormatter(FrameFormatter):
                                    truncation=self.truncate_vals,
                                    wrap=self.line_wrap)
             assign_str = self.val_tpl % (name, val_str)
-            hue, sat, val, bold = colormap.get(name, self.colors['var_invisible'])
-            clr_str = get_ansi_tpl(hue, sat, val, bold) % assign_str
+            clr_str = colormap.get(name, self.colors['var_invisible']) % assign_str
             msgs.append(clr_str)
         if len(msgs) > 0:
             return self.sep_vars + '\n' + ''.join(msgs) + self.sep_vars + '\n\n'

--- a/stackprinter/utils.py
+++ b/stackprinter/utils.py
@@ -1,7 +1,5 @@
 import re
-import types
 import inspect
-import colorsys
 from collections import OrderedDict
 
 
@@ -79,22 +77,3 @@ def trim_source(source_map, context):
         trimmed_source_map[ln] = [[snippet0] + meta0] + remaining_line
 
     return trimmed_source_map
-
-
-
-def get_ansi_tpl(hue, sat, val, bold=False):
-
-    # r_, g_, b_ = colorsys.hls_to_rgb(hue, val, sat)
-    r_, g_, b_ = colorsys.hsv_to_rgb(hue, sat, val)
-    r = int(round(r_*5))
-    g = int(round(g_*5))
-    b = int(round(b_*5))
-    point = 16 + 36 * r + 6 * g + b
-    # print(r,g,b,point)
-
-    bold_tp = '1;' if bold else ''
-    code_tpl = ('\u001b[%s38;5;%dm' % (bold_tp, point)) + '%s\u001b[0m'
-    return code_tpl
-
-
-


### PR DESCRIPTION
Many terminals allow to customize the appearance. The basic colors can be overridden, but the ANSI 256 colors not. 

For example, there can be solarized, light, and dark themes for the terminal having the basic colors fine-tuned for it.

(I also have to switch frequently between light and dark mode, based on the environment lightning.)